### PR TITLE
docs: Note distinct scs / scs-validate console scripts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ Two **independent** Python packages live under `tools/` — there is no top-leve
 Each has its own `pyproject.toml`; install and test them separately. Both require **Python ≥ 3.11**.
 There is no CI workflow yet, so run these locally before submitting.
 
+The two packages expose **distinct** console scripts — `scs` (scaffolding, `scs-tools`) and
+`scs-validate` (validation, `scs-validator`). Keep them distinct: both once declared `scs`,
+which collided when installed together. Don't rename either back to a shared name.
+
 ### `tools/cli/` — `scs-tools` (project scaffolding)
 
 Click-based CLI exposing the `scs` command (`scs_tools.cli:cli`). Subcommands: `new`, `init`,


### PR DESCRIPTION
## Summary

Follow-up to #16. Adds a short callout in the **Tools & Development Commands** section of `CLAUDE.md` making the two console scripts explicit and guarding against regression:

- `scs` — scaffolding (`scs-tools`)
- `scs-validate` — validation (`scs-validator`)

Both packages once declared `scs`, which collided when installed together (fixed in #16). The note tells future contributors to keep the names distinct rather than re-merging them.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)