### PR TITLE
Add Medical-Device CDMO domain (reference)

### DIFF
--- a/examples/medical-device-cdmo/README.md
+++ b/examples/medical-device-cdmo/README.md
@@ -1,0 +1,47 @@
+# Medical-Device CDMO Domain (reference)
+
+A reference SCS domain for **contract development & manufacturing organizations (CDMOs)** in the
+medical-device industry: regulated QMS work, computer-system validation, multi-client program
+segregation, and — the reason this domain exists — the **governance of AI assistants** operating
+inside that environment.
+
+It adapts the software-development reference domain to a regulated medical-device CDMO:
+
+- **Kept** where they fit: `compliance-governance`, `data-provenance`, `security`, `business-context`.
+- **Renamed** where the meaning shifts (the rename is deliberate, so the divergence is visible):
+  - `architecture` → `system-architecture` (solution/integration/config, not source code)
+  - `testing-validation` → `verification-validation` (CSV lifecycle: IQ/OQ/PQ, requirements traceability)
+  - `safety-risk` → `risk-management` (ISO 14971 + project + data-integrity risk)
+  - `deployment-operations` → `implementation-cutover` (migration, multi-site rollout, rollback)
+  - `ethics-ai-accountability` → `ai-accountability`
+- **Added** where the software set has no home:
+  - `training-competency` (role-based qualification; ISO 13485 §6.2)
+  - `qms-records` (document control, CAPA, retention, systems of record)
+  - `supplier-qualification` (GAMP supplier assessment; AI-vendor qualification)
+- **Dropped**: `performance-reliability`, `usability-accessibility` (device human factors has no AI agent in it).
+
+**Inclusion rule:** a concern belongs in this domain only where an AI agent actually operates.
+
+## Generic, not customer-specific
+
+This directory contains the **generic** domain structure only — concern definitions and the SCD
+*slots* a CDMO program would fill. It contains **no** organization-specific rules, values, or data.
+A specific CDMO's actual context (its tier definitions, its retention periods, its program data) is
+authored as project-tier SCDs in that organization's **own private workspace**, which imports this
+domain by version. The structure is generic; the values are the organization's.
+
+## Layout
+
+```
+medical-device-cdmo/
+├── domains/medical-device-cdmo.yaml   ← domain bundle (imports the 12 concerns)
+└── concerns/                          ← the 12 concern bundles (generic SCD slots)
+```
+
+Domain manifest: `schema/domain/examples/medical-device-cdmo-domain.yaml`.
+
+## Provenance
+
+Generalized from a real engagement (a CDMO AI-governance proof of concept). Contributed back as a
+reusable domain because the gap it fills — the software-dev ontology not fitting regulated
+medical-device work — is one every CDMO shares.

--- a/examples/medical-device-cdmo/concerns/ai-accountability.yaml
+++ b/examples/medical-device-cdmo/concerns/ai-accountability.yaml
@@ -1,0 +1,30 @@
+# ================================================================
+# Concern Bundle: AI Accountability
+# ================================================================
+# RENAMED from `ethics-ai-accountability`: human authority, the
+# non-decision principle, named accountability, bias handling.
+# Generic SCD slots.
+# ================================================================
+
+id: bundle:ai-accountability
+type: concern
+version: "0.1.0"
+title: "AI Accountability Concern Bundle"
+description: >
+  AI accountability for a medical-device CDMO: human decision authority
+  and sign-off gates, the non-decision principle (automated controls do
+  not approve), named accountability for AI-assisted output, and the
+  method for handling AI limitations and bias.
+
+imports: []
+
+scds:
+  - scd:project:human-authority
+  - scd:project:non-decision-principle
+  - scd:project:accountability-assignment
+  - scd:project:bias-mitigation
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic ai-accountability concern (renamed from ethics-ai-accountability) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/business-context.yaml
+++ b/examples/medical-device-cdmo/concerns/business-context.yaml
@@ -1,0 +1,28 @@
+# ================================================================
+# Concern Bundle: Business Context
+# ================================================================
+# Why the program exists, its scope, success criteria, and the client
+# program it serves. Generic SCD slots.
+# ================================================================
+
+id: bundle:business-context
+type: concern
+version: "0.1.0"
+title: "Business Context Concern Bundle"
+description: >
+  Business context for a medical-device CDMO program: objectives and
+  business case, explicit scope boundaries, measurable success criteria,
+  and the client-program context the work serves.
+
+imports: []
+
+scds:
+  - scd:project:program-objectives
+  - scd:project:scope-definition
+  - scd:project:success-criteria
+  - scd:project:client-program-context
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic business-context concern for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/compliance-governance.yaml
+++ b/examples/medical-device-cdmo/concerns/compliance-governance.yaml
@@ -1,0 +1,30 @@
+# ================================================================
+# Concern Bundle: Compliance & Governance
+# ================================================================
+# Regulatory + QMS guardrails and the AI-use governance rules an
+# assistant must operate inside (deployment tiers, autonomy, Part 11,
+# prohibited uses). Generic SCD slots — values are organization-specific.
+# ================================================================
+
+id: bundle:compliance-governance
+type: concern
+version: "0.1.0"
+title: "Compliance & Governance Concern Bundle"
+description: >
+  Regulatory and QMS governance for a medical-device CDMO: which
+  regulations bind the work, the AI deployment-tier and autonomy rules,
+  electronic-records controls, and hard prohibitions on AI use.
+
+imports: []
+
+scds:
+  - scd:project:regulatory-applicability
+  - scd:project:ai-deployment-tiers
+  - scd:project:agent-autonomy-rules
+  - scd:project:electronic-records-controls
+  - scd:project:prohibited-uses
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic compliance-governance concern for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/data-provenance.yaml
+++ b/examples/medical-device-cdmo/concerns/data-provenance.yaml
@@ -1,0 +1,29 @@
+# ================================================================
+# Concern Bundle: Data & Provenance
+# ================================================================
+# Data classification, lineage, integrity (ALCOA+), RAG source
+# precedence, and multi-client segregation. Generic SCD slots.
+# ================================================================
+
+id: bundle:data-provenance
+type: concern
+version: "0.1.0"
+title: "Data & Provenance Concern Bundle"
+description: >
+  Data governance for a medical-device CDMO: classification scheme,
+  source-to-target lineage, ALCOA+ integrity, RAG source-precedence
+  rules, and client-program data segregation.
+
+imports: []
+
+scds:
+  - scd:project:data-classification
+  - scd:project:data-lineage
+  - scd:project:data-integrity-alcoa
+  - scd:project:rag-source-precedence
+  - scd:project:client-program-segregation
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic data-provenance concern for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/implementation-cutover.yaml
+++ b/examples/medical-device-cdmo/concerns/implementation-cutover.yaml
@@ -1,0 +1,29 @@
+# ================================================================
+# Concern Bundle: Implementation & Cutover
+# ================================================================
+# RENAMED from `deployment-operations`: migration, multi-site rollout,
+# rollback, hypercare. Generic SCD slots.
+# ================================================================
+
+id: bundle:implementation-cutover
+type: concern
+version: "0.1.0"
+title: "Implementation & Cutover Concern Bundle"
+description: >
+  Implementation and cutover for a medical-device CDMO program: the
+  cutover plan and sequence, multi-site rollout (including role/licensing
+  differences), rollback triggers and procedure, and hypercare / go-live
+  criteria.
+
+imports: []
+
+scds:
+  - scd:project:cutover-plan
+  - scd:project:rollout-sequence
+  - scd:project:rollback-criteria
+  - scd:project:hypercare-plan
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic implementation-cutover concern (renamed from deployment-operations) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/qms-records.yaml
+++ b/examples/medical-device-cdmo/concerns/qms-records.yaml
@@ -1,0 +1,28 @@
+# ================================================================
+# Concern Bundle: QMS Records
+# ================================================================
+# ADDED concern (no home in the software-dev set): document control,
+# CAPA, retention, systems of record. Generic SCD slots.
+# ================================================================
+
+id: bundle:qms-records
+type: concern
+version: "0.1.0"
+title: "QMS Records Concern Bundle"
+description: >
+  QMS records management for a medical-device CDMO: document hierarchy
+  and control rules, record-retention rules, CAPA triggers, and which
+  records are authoritative systems of record (AI output is never one).
+
+imports: []
+
+scds:
+  - scd:project:document-control
+  - scd:project:record-retention
+  - scd:project:capa-triggers
+  - scd:project:system-of-record-designation
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic qms-records concern (added) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/risk-management.yaml
+++ b/examples/medical-device-cdmo/concerns/risk-management.yaml
@@ -1,0 +1,29 @@
+# ================================================================
+# Concern Bundle: Risk Management
+# ================================================================
+# RENAMED from `safety-risk`: ISO 14971 + project + data-integrity
+# risk (patient-safety only where device-intersecting). Generic SCD slots.
+# ================================================================
+
+id: bundle:risk-management
+type: concern
+version: "0.1.0"
+title: "Risk Management Concern Bundle"
+description: >
+  Risk management for a medical-device CDMO program: the risk register
+  (probability x severity with controls), risk-to-requirement-to-
+  controlling-deliverable traceability, data-integrity risk controls,
+  and risk-acceptability criteria per ISO 14971.
+
+imports: []
+
+scds:
+  - scd:project:risk-register
+  - scd:project:risk-traceability
+  - scd:project:data-integrity-risk
+  - scd:project:risk-acceptability-criteria
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic risk-management concern (renamed from safety-risk) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/security.yaml
+++ b/examples/medical-device-cdmo/concerns/security.yaml
@@ -1,0 +1,27 @@
+# ================================================================
+# Concern Bundle: Security
+# ================================================================
+# Access model and the validated-system boundaries an AI assistant
+# must respect. Generic SCD slots.
+# ================================================================
+
+id: bundle:security
+type: concern
+version: "0.1.0"
+title: "Security Concern Bundle"
+description: >
+  Security context for a medical-device CDMO: access-control model,
+  the boundaries an assistant may touch in validated/QMS systems, and
+  data-loss-prevention controls at the AI boundary.
+
+imports: []
+
+scds:
+  - scd:project:access-control-model
+  - scd:project:validated-system-boundaries
+  - scd:project:data-loss-prevention
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic security concern for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/supplier-qualification.yaml
+++ b/examples/medical-device-cdmo/concerns/supplier-qualification.yaml
@@ -1,0 +1,29 @@
+# ================================================================
+# Concern Bundle: Supplier Qualification
+# ================================================================
+# ADDED concern (no home in the software-dev set): GAMP supplier
+# assessment for platforms AND AI vendors. Generic SCD slots.
+# ================================================================
+
+id: bundle:supplier-qualification
+type: concern
+version: "0.1.0"
+title: "Supplier Qualification Concern Bundle"
+description: >
+  Supplier and vendor qualification for a medical-device CDMO: GAMP
+  supplier assessment for platform vendors, per-tier vendor approval,
+  re-qualification triggers, and AI-vendor qualification (SOC 2, BAA,
+  model provenance, training opt-out).
+
+imports: []
+
+scds:
+  - scd:project:supplier-assessment
+  - scd:project:vendor-tier-approval
+  - scd:project:requalification-triggers
+  - scd:project:ai-vendor-qualification
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic supplier-qualification concern (added) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/system-architecture.yaml
+++ b/examples/medical-device-cdmo/concerns/system-architecture.yaml
@@ -1,0 +1,29 @@
+# ================================================================
+# Concern Bundle: System Architecture
+# ================================================================
+# RENAMED from `architecture`: in a CDMO this means solution /
+# integration / configuration design, NOT source code. Generic SCD slots.
+# ================================================================
+
+id: bundle:system-architecture
+type: concern
+version: "0.1.0"
+title: "System Architecture Concern Bundle"
+description: >
+  Solution architecture for a medical-device CDMO program: target
+  system design and configuration, integration topology, target data/
+  object model, and the architectural constraints an assistant must not
+  drift from. Solution-level, not source code.
+
+imports: []
+
+scds:
+  - scd:project:solution-architecture
+  - scd:project:integration-map
+  - scd:project:target-data-model
+  - scd:project:architecture-constraints
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic system-architecture concern (renamed from architecture) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/training-competency.yaml
+++ b/examples/medical-device-cdmo/concerns/training-competency.yaml
@@ -1,0 +1,28 @@
+# ================================================================
+# Concern Bundle: Training & Competency
+# ================================================================
+# ADDED concern (no home in the software-dev set): who is qualified to
+# do and review the work. ISO 13485 §6.2. Generic SCD slots.
+# ================================================================
+
+id: bundle:training-competency
+type: concern
+version: "0.1.0"
+title: "Training & Competency Concern Bundle"
+description: >
+  Training and competency for a medical-device CDMO program: the
+  role-to-required-competency matrix, the definition of a qualified
+  reviewer (who may approve AI-assisted output), and training-completion
+  gates on system/data access.
+
+imports: []
+
+scds:
+  - scd:project:role-competency-matrix
+  - scd:project:qualified-reviewer-definition
+  - scd:project:training-completion-gates
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic training-competency concern (added) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/concerns/verification-validation.yaml
+++ b/examples/medical-device-cdmo/concerns/verification-validation.yaml
@@ -1,0 +1,29 @@
+# ================================================================
+# Concern Bundle: Verification & Validation
+# ================================================================
+# RENAMED from `testing-validation`: the CSV lifecycle (IQ/OQ/PQ),
+# requirements traceability, and acceptance criteria. Generic SCD slots.
+# ================================================================
+
+id: bundle:verification-validation
+type: concern
+version: "0.1.0"
+title: "Verification & Validation Concern Bundle"
+description: >
+  Computer-system validation for a medical-device CDMO program: the
+  validation approach (GAMP category; IQ/OQ/PQ), requirements (URS)
+  traceability, quantitative acceptance criteria, and qualification
+  protocols and evidence.
+
+imports: []
+
+scds:
+  - scd:project:validation-approach
+  - scd:project:requirements-traceability
+  - scd:project:acceptance-criteria
+  - scd:project:qualification-protocols
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Generic verification-validation concern (renamed from testing-validation) for the Medical-Device CDMO domain"

--- a/examples/medical-device-cdmo/context-intake-template.md
+++ b/examples/medical-device-cdmo/context-intake-template.md
@@ -1,0 +1,118 @@
+# Medical-Device CDMO — Context Intake Template
+
+> **Generic.** This template defines what *concrete* context a medical-device CDMO must supply for
+> each of the 12 concerns before its context can be authored into SCS bundles. It contains no
+> organization-specific values — a specific CDMO records its readiness and its actual rules in its
+> own private workspace, against this template.
+
+---
+
+## 1. The bar: what "good context" is
+
+A unit of context is usable in a bundle only if it is all three:
+
+1. **Concrete** — it stipulates an actual limit, rule, value, or boundary. "Use appropriate tools"
+   is not concrete; "Client-confidential data may go only to the highest-tier tools" is.
+2. **Terminal** — it is self-contained. It does not dangle to a document you don't have. "Per the
+   approved-tool register" is a pointer; the register's actual contents are terminal.
+3. **Agent-relevant** — it shapes what an AI assistant may, must, or must not do. If no agent
+   operates in it, it is not a concern in this domain.
+
+### Readiness states
+
+| State | Meaning | The follow-up |
+|---|---|---|
+| ✅ **Have it** | Concrete and terminal — ready to author into an SCD | none |
+| 🟡 **Pointer** | The rule exists but dangles to an absent artifact | **Retrieve** the artifact |
+| ❌ **Gap** | No concrete limit was ever stipulated | **Decide** it — name the decision + an owner |
+| ⚪ **N/A** | No agent operates here | record the rationale, move on |
+
+The 🟡-vs-❌ split is the point: **🟡 is a fetch; ❌ is a decision.** Separating them keeps a
+"get us better context" request from stalling on the items nobody has decided yet.
+
+### Generic worked example
+
+- ✅ **Good:** a documented, ordered source-precedence hierarchy with explicit conflict-resolution
+  rules. Concrete, terminal, near-executable — *the target shape for every SCD.*
+- ❌ **Gap:** "outputs must be reviewed for potential bias," with no method, threshold, or trigger.
+  Unfalsifiable — an agent can't act on it and an auditor can't check it.
+
+---
+
+## 2. The 12 concerns — what to stipulate
+
+For each concern: its purpose, the concrete items to stipulate, and a generic good-vs-pointer cue.
+
+### 1. `compliance-governance`
+**Stipulate:** the data-class → permitted-AI-tool/tier mapping; autonomy rules (what an assistant may
+do without named sign-off, by workflow type); the hard "never" prohibitions; which specific regulatory
+clauses bind the work (→ standards tier).
+**Good:** "Client-confidential → highest-tier tools only; consumer chat prohibited." **Pointer:** "per the approved-tool register."
+
+### 2. `data-provenance`
+**Stipulate:** the data-classification scheme with examples; source-precedence / conflict-resolution
+rules; source→target lineage + reconciliation / ALCOA+ integrity criteria (for migrations); permitted
+sources per client program (segregation).
+**Good:** "an ordered 5-level source-precedence hierarchy with explicit conflict rules." **Pointer:** "data mapping per the migration spec."
+
+### 3. `security`
+**Stipulate:** the access-control model (who/what reaches which systems); validated-system boundaries
+(assistant read-only? writes gated?); DLP / data-handling at the AI boundary.
+**Good:** "assistants read-only to the QMS; no controlled-record writes without qualified, gated approval." **Pointer:** "per IT-security review."
+
+### 4. `business-context`
+**Stipulate:** program objectives & business case; explicit in/out scope; measurable success criteria;
+client program(s) served and their constraints.
+**Good:** "migrate System A → System B across 3 sites by [date]; success = all controlled records migrated & validated." **Pointer:** "see the project charter."
+
+### 5. `system-architecture`
+**Stipulate:** target system architecture/configuration; integration topology; target data/object
+model; architectural constraints the assistant must not drift from.
+**Good:** "approved target objects X/Y/Z; integration to System C via interface A; no unapproved custom objects." **Pointer:** "per the solution design."
+
+### 6. `verification-validation`
+**Stipulate:** validation approach (GAMP category; IQ/OQ/PQ); requirements (URS) with stable IDs;
+quantitative acceptance criteria; qualification protocols & evidence.
+**Good:** "URS-014 → OQ-22 → accept at 100% record-count match." **Pointer:** "per the validation plan."
+
+### 7. `risk-management`
+**Stipulate:** the risk register (probability × severity + controls); risk → requirement →
+controlling-deliverable traceability; data-integrity risk controls; risk-acceptability criteria.
+**Good:** "Risk-14, P×S, control = X, traces to URS-Y, residual acceptable." **Pointer:** "per the risk file."
+
+### 8. `implementation-cutover`
+**Stipulate:** cutover plan & sequence; multi-site rollout specifics (role/licensing differences);
+rollback triggers & procedure; hypercare / go-live criteria.
+**Good:** "wave 1 [site/date]; rollback if reconciliation < 99%." **Pointer:** "per the cutover plan."
+
+### 9. `ai-accountability`
+**Stipulate:** the concrete human sign-off gates (what requires named-human review); the non-decision
+principle (AI never decides); accountability assignment (who owns AI-assisted output); a bias /
+limitation handling **method**.
+**Good:** "AI output to a controlled record requires named-engineer sign-off + independent reproduction." **Gap:** "review for bias" (no method).
+
+### 10. `training-competency`
+**Stipulate:** the role → required-competency matrix; the definition of a qualified reviewer (who may
+approve AI output); training-completion gates on access; site/role competency differences.
+**Good:** "only Part 11-trained engineers may approve migrated controlled records." **Pointer:** "per the training plan."
+
+### 11. `qms-records`
+**Stipulate:** the document hierarchy & control rules; record-retention rules; CAPA triggers; which
+records are authoritative systems of record (AI output never is).
+**Good:** "AI contribution log retained [lifecycle + N yr]; AI output is a working artifact until transferred to the SoR." **Pointer:** "per the record-retention procedure."
+
+### 12. `supplier-qualification`
+**Stipulate:** AI-vendor qualification criteria & current status; platform supplier qualification (GAMP
+supplier assessment); per-tier vendor approval; re-qualification triggers.
+**Good:** "Vendor V — tier-2 approved, tier-3 conditional, SOC 2 Type II, BAA available, confirmed [date]." **Pointer:** "see the vendor register."
+
+---
+
+## 3. How to use it
+
+1. **Walk the 12 concerns**, not your source documents. For each, ask: is there a concrete, terminal
+   stipulation? Mark ✅ / 🟡 / ❌ / ⚪.
+2. **For every 🟡 — retrieve the artifact.** It exists; collect it.
+3. **For every ❌ — name the decision and an owner.** No one has set this limit; someone must. Park
+   what can't be decided yet; don't let it stall the rest.
+4. **A concern is bundle-ready when its items are all ✅.** That is the gate into authoring its SCDs.

--- a/examples/medical-device-cdmo/domains/medical-device-cdmo.yaml
+++ b/examples/medical-device-cdmo/domains/medical-device-cdmo.yaml
@@ -1,0 +1,39 @@
+# ================================================================
+# Domain Bundle: Medical-Device CDMO
+# ================================================================
+# Imports all concern bundles relevant to a regulated medical-device
+# CDMO and the AI assistants operating within it. Domain bundles
+# import concerns and contain no SCDs of their own.
+# ================================================================
+
+id: bundle:medical-device-cdmo
+type: domain
+version: "0.1.0"
+title: "Medical-Device CDMO Domain"
+description: >
+  Medical-Device CDMO domain bundle importing all concern bundles for
+  regulated QMS work, computer-system validation, multi-client program
+  segregation, and the governance of AI assistants in design, quality,
+  and regulatory workflows.
+
+imports:
+  - bundle:compliance-governance:0.1.0
+  - bundle:data-provenance:0.1.0
+  - bundle:security:0.1.0
+  - bundle:business-context:0.1.0
+  - bundle:system-architecture:0.1.0
+  - bundle:verification-validation:0.1.0
+  - bundle:risk-management:0.1.0
+  - bundle:implementation-cutover:0.1.0
+  - bundle:ai-accountability:0.1.0
+  - bundle:training-competency:0.1.0
+  - bundle:qms-records:0.1.0
+  - bundle:supplier-qualification:0.1.0
+
+# Domain bundles don't contain SCDs directly - they import concerns
+scds: []
+
+provenance:
+  created_by: "info@ohana-tech.com"
+  created_at: "2026-06-04T00:00:00Z"
+  rationale: "Medical-Device CDMO domain v0.1.0 - generic reference structure (12 concerns)"

--- a/schema/domain/examples/medical-device-cdmo-domain.yaml
+++ b/schema/domain/examples/medical-device-cdmo-domain.yaml
@@ -1,0 +1,85 @@
+domain:
+  id: "domain:medical-device-cdmo"
+  name: "Medical-Device CDMO"
+  version: "0.1.0"
+  description: "Structured context for contract development & manufacturing organizations (CDMOs) in the medical-device industry — regulated QMS work, computer-system validation, multi-client program segregation, and the governance of AI assistants operating inside that environment."
+  author: "Ohana Consulting"
+  license: "open"
+  homepage: "https://structuredcontext.dev/domains/medical-device-cdmo"
+
+  # The 12 concerns of this domain. Derived by adapting the software-development
+  # reference set to a regulated medical-device CDMO: concerns kept where they fit,
+  # renamed where the meaning shifts (e.g. architecture -> system-architecture,
+  # testing-validation -> verification-validation), and added where the domain has
+  # needs the software set has no home for (qms-records, supplier-qualification,
+  # training-competency). Inclusion rule: a concern belongs here only where AI
+  # agents actually operate.
+  concerns:
+    - "bundle:compliance-governance:0.1.0"
+    - "bundle:data-provenance:0.1.0"
+    - "bundle:security:0.1.0"
+    - "bundle:business-context:0.1.0"
+    - "bundle:system-architecture:0.1.0"
+    - "bundle:verification-validation:0.1.0"
+    - "bundle:risk-management:0.1.0"
+    - "bundle:implementation-cutover:0.1.0"
+    - "bundle:ai-accountability:0.1.0"
+    - "bundle:training-competency:0.1.0"
+    - "bundle:qms-records:0.1.0"
+    - "bundle:supplier-qualification:0.1.0"
+
+  # Shared base SCD schemas (inherited from the core spec, as in the sibling domains).
+  schemas:
+    meta:
+      content_schema: "../../scd/meta-scd-content-schema.json"
+      template: "../../scd/meta-scd-template.json"
+
+    standards:
+      content_schema: "../../scd/standards-scd-content-schema.json"
+      template: "../../scd/standards-scd-template.json"
+
+    project:
+      content_schema: "../../scd/project-scd-content-schema.json"
+      template: "../../scd/project-scd-template.json"
+
+  examples:
+    - "../../../examples/medical-device-cdmo/README.md"
+
+  metadata:
+    tags:
+      - "medical-device"
+      - "cdmo"
+      - "qms"
+      - "computer-system-validation"
+      - "iso-13485"
+      - "21-cfr-part-11"
+      - "ai-governance"
+
+    industry:
+      - "Medical Devices"
+      - "Life Sciences"
+      - "Contract Manufacturing"
+
+    use_cases:
+      - "QMS / PLM system implementation and migration"
+      - "Regulated document authoring (DHF, SOPs, validation protocols)"
+      - "Computer-system validation (IQ/OQ/PQ)"
+      - "Multi-client program governance and segregation"
+      - "Governance of AI assistants in design, quality, and regulatory workflows"
+
+# Domain-specific content structure preview:
+#
+# Meta-tier content (roles, concepts, capabilities):
+#   - cdmo_roles: [quality_engineer, regulatory_lead, validation_engineer, ...]
+#   - data_classifications: [public, internal, client_confidential, trade_secret, regulated]
+#   - agent_autonomy_levels: [L1_human_in_loop, L2_human_on_loop, L3_autonomous]
+#   - deployment_tiers: [tier_1_public, tier_2_confidential, tier_3_regulated]
+#
+# Standards-tier content (regulations the domain implements):
+#   - quality_system: [ISO 13485, 21 CFR 820 / QMSR]
+#   - software_lifecycle: [IEC 62304, 21 CFR Part 11, GAMP 5]
+#   - risk: [ISO 14971, ISO/IEC 23894]
+#   - ai_governance: [EU AI Act, ISO/IEC 42001, NIST AI RMF, FDA AI guidances]
+#
+# Project-tier content (per-program implementation):
+#   - the SCDs declared by each concern bundle in examples/medical-device-cdmo/concerns/


### PR DESCRIPTION
## What

A reference SCS domain for **medical-device CDMOs** (contract development & manufacturing organizations): regulated QMS work, computer-system validation, multi-client program segregation, and the governance of AI assistants operating within that environment.

It sits alongside the existing `software-development` and `healthcare` domain examples.

## Why

The software-development reference set doesn't fit regulated medical-device work — `architecture` reads as *source code*, `testing` as *software QA*, and there's no home at all for training/competency. Rather than bend a CDMO's reality to that set, this defines a domain in the shape of the work. The gap is one every CDMO shares, so the domain is contributed as a reusable reference.

## The 12 concerns

- **Kept:** `compliance-governance`, `data-provenance`, `security`, `business-context`
- **Renamed** (meaning shifts — renamed deliberately so the divergence is visible):
  - `architecture` → `system-architecture` (solution/integration/config, not source code)
  - `testing-validation` → `verification-validation` (CSV: IQ/OQ/PQ, requirements traceability)
  - `safety-risk` → `risk-management` (ISO 14971 + project + data-integrity risk)
  - `deployment-operations` → `implementation-cutover` (migration, multi-site rollout, rollback)
  - `ethics-ai-accountability` → `ai-accountability`
- **Added:** `training-competency` (ISO 13485 §6.2), `qms-records` (doc control, CAPA, retention), `supplier-qualification` (GAMP supplier + AI-vendor qualification)
- **Dropped:** `performance-reliability`, `usability-accessibility`

**Inclusion rule:** a concern belongs only where an AI agent actually operates.

## Contents

- `schema/domain/examples/medical-device-cdmo-domain.yaml` — domain manifest (12 concerns)
- `examples/medical-device-cdmo/` — domain bundle + 12 concern bundles + README + generic context-intake template

## Notes

- **Generic only** — concern bundles declare project-tier SCD *slots*; no organization-specific values. A specific CDMO authors its actual SCDs in its own private workspace, importing this domain by version.
- Manifest validated against `domain-manifest-schema.json`; concern bundles conform (type `concern`, empty imports, ≥1 SCD); domain imports match the manifest's concern list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
